### PR TITLE
v5.4

### DIFF
--- a/dist/check-group/core/config_getter.js
+++ b/dist/check-group/core/config_getter.js
@@ -91,14 +91,14 @@ var fetchConfig = function (context) { return __awaiter(void 0, void 0, void 0, 
                 core.debug("fetchConfig ".concat(repoFullName, " ").concat(githubRepository));
                 if (!(repoFullName == githubRepository)) return [3 /*break*/, 2];
                 prBranch = payload.pull_request.head.ref;
-                core.info("The PR is from a branch in the repository. Reading the config in ".concat(prBranch));
+                core.info("The PR is from a branch in the repository. Reading the config in '".concat(prBranch, "'"));
                 return [4 /*yield*/, readConfig(context, prBranch)];
             case 1:
                 configData = _a.sent();
                 return [3 /*break*/, 4];
             case 2:
                 baseBranch = payload.pull_request.base.ref;
-                core.info("The PR is from a fork (".concat(repoFullName, "). For security, reading the config in ").concat(baseBranch));
+                core.info("The PR is from a fork: '".concat(repoFullName, "'. For security, reading the config in '").concat(baseBranch, "'"));
                 return [4 /*yield*/, readConfig(context, baseBranch)];
             case 3:
                 configData = _a.sent();

--- a/dist/check-group/core/generate_progress.js
+++ b/dist/check-group/core/generate_progress.js
@@ -59,7 +59,9 @@ var statusToLink = function (check, postedChecks) {
     if (check in postedChecks) {
         var checkData = postedChecks[check];
         // assert(checkData.name === check)
-        return "[".concat(check, "](").concat(checkData.details_url, ")");
+        // if the check name contains the character "|", it will break the table rendering
+        var sanitizedCheck = check.replace(/\|/g, "\\|");
+        return "[".concat(sanitizedCheck, "](").concat(checkData.details_url, ")");
     }
     return check;
 };

--- a/dist/check-group/core/index.js
+++ b/dist/check-group/core/index.js
@@ -240,9 +240,13 @@ var getPostedChecks = function (context, sha) { return __awaiter(void 0, void 0,
                         name: checkRun.name,
                         status: checkRun.status,
                         conclusion: checkRun.conclusion,
-                        details_url: checkRun.details_url
+                        details_url: checkRun.details_url,
+                        completed_at: new Date(checkRun.completed_at),
                     };
-                    checkNames[checkRun.name] = checkRunData;
+                    // "filter: latest" doesnt seem to work as expected so we need to check the completed_at in case of collisions
+                    if (!checkNames[checkRun.name] || checkNames[checkRun.name].completed_at < checkRunData.completed_at) {
+                        checkNames[checkRun.name] = checkRunData;
+                    }
                 });
                 return [2 /*return*/, checkNames];
         }

--- a/dist/check-group/core/index.js
+++ b/dist/check-group/core/index.js
@@ -243,9 +243,15 @@ var getPostedChecks = function (context, sha) { return __awaiter(void 0, void 0,
                         details_url: checkRun.details_url,
                         completed_at: new Date(checkRun.completed_at),
                     };
-                    // "filter: latest" doesnt seem to work as expected so we need to check the completed_at in case of collisions
-                    if (!checkNames[checkRun.name] || checkNames[checkRun.name].completed_at < checkRunData.completed_at) {
+                    if (!checkNames[checkRun.name]) {
                         checkNames[checkRun.name] = checkRunData;
+                    }
+                    else {
+                        core.debug("Conflict for ".concat(checkRun.name, ": previous=").concat(checkNames[checkRun.name].completed_at, ", new=").concat(checkRunData.completed_at));
+                        // "filter: latest" doesnt seem to work as expected so we need to check `completed_at` in case of collisions
+                        if (checkNames[checkRun.name].completed_at < checkRunData.completed_at) {
+                            checkNames[checkRun.name] = checkRunData;
+                        }
                     }
                 });
                 return [2 /*return*/, checkNames];

--- a/src/check-group/core/generate_progress.ts
+++ b/src/check-group/core/generate_progress.ts
@@ -31,7 +31,9 @@ const statusToLink = (
   if (check in postedChecks) {
     const checkData = postedChecks[check]
     // assert(checkData.name === check)
-    return `[${check}](${checkData.details_url})`
+    // if the check name contains the character "|", it will break the table rendering
+    const sanitizedCheck = check.replace(/\|/g, "\\|")
+    return `[${sanitizedCheck}](${checkData.details_url})`
   }
   return check
 }

--- a/src/check-group/core/index.ts
+++ b/src/check-group/core/index.ts
@@ -175,9 +175,14 @@ const getPostedChecks = async (context: Context, sha: string): Promise<Record<st
         details_url: checkRun.details_url,
         completed_at: new Date(checkRun.completed_at),
       }
-      // "filter: latest" doesnt seem to work as expected so we need to check the completed_at in case of collisions
-      if (!checkNames[checkRun.name] || checkNames[checkRun.name].completed_at < checkRunData.completed_at) {
+      if (!checkNames[checkRun.name]) {
         checkNames[checkRun.name] = checkRunData;
+      } else {
+        core.debug(`Conflict for ${checkRun.name}: previous=${checkNames[checkRun.name].completed_at}, new=${checkRunData.completed_at}`)
+        // "filter: latest" doesnt seem to work as expected so we need to check `completed_at` in case of collisions
+        if (checkNames[checkRun.name].completed_at < checkRunData.completed_at) {
+          checkNames[checkRun.name] = checkRunData;
+        }
       }
     },
   );

--- a/src/check-group/core/index.ts
+++ b/src/check-group/core/index.ts
@@ -172,9 +172,13 @@ const getPostedChecks = async (context: Context, sha: string): Promise<Record<st
         name: checkRun.name,
         status: checkRun.status,
         conclusion: checkRun.conclusion,
-        details_url: checkRun.details_url
+        details_url: checkRun.details_url,
+        completed_at: new Date(checkRun.completed_at),
       }
-      checkNames[checkRun.name] = checkRunData;
+      // "filter: latest" doesnt seem to work as expected so we need to check the completed_at in case of collisions
+      if (!checkNames[checkRun.name] || checkNames[checkRun.name].completed_at < checkRunData.completed_at) {
+        checkNames[checkRun.name] = checkRunData;
+      }
     },
   );
   return checkNames;

--- a/src/check-group/types.ts
+++ b/src/check-group/types.ts
@@ -48,4 +48,5 @@ export interface CheckRunData {
   status: Status;
   conclusion: Conclusion;
   details_url: string;
+  completed_at: Date,
 }


### PR DESCRIPTION
- Manually check the `completed_at` field in case of collisions. This issue seems to happen (sometimes?) on PRs where the jobs have been rerun manually multiple times.
- Fix markdown table rendering when the run name has `|`