### PR TITLE
fix: Probot's use of ** aligns with Github's and matches paths like `.github/X` and `abc/.env`

### DIFF
--- a/dist/check-group/core/subproj_matching.js
+++ b/dist/check-group/core/subproj_matching.js
@@ -21,7 +21,12 @@ var matchFilenamesToSubprojects = function (filenames, subprojConfigs) {
             // https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-including-and-excluding-paths
             var isNegation = path.startsWith("!");
             // https://www.npmjs.com/package/minimatch
-            var matches = minimatch_1.default.match(filenames, path, { "flipNegate": isNegation });
+            // `dot: true` aligns with GitHub Actions' own `paths:` filter, which uses
+            // minimatch with the same option — without it, patterns like `**` would
+            // silently fail to match paths containing dot-prefixed segments (e.g.
+            // `.github/foo` or `my-project/.env.staging`), causing subprojects to
+            // appear inactive for PRs that touch only such paths.
+            var matches = minimatch_1.default.match(filenames, path, { "flipNegate": isNegation, "dot": true });
             // if it's a negation, delete from the list of hits, otherwise add
             matches.forEach(function (match) { return (isNegation) ? hits.delete(match) : hits.add(match); });
         });

--- a/src/check-group/core/subproj_matching.ts
+++ b/src/check-group/core/subproj_matching.ts
@@ -21,7 +21,12 @@ export const matchFilenamesToSubprojects = (
       // https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-including-and-excluding-paths
       const isNegation = path.startsWith("!")
       // https://www.npmjs.com/package/minimatch
-      const matches = minimatch.match(filenames, path, {"flipNegate": isNegation})
+      // `dot: true` aligns with GitHub Actions' own `paths:` filter, which uses
+      // minimatch with the same option — without it, patterns like `**` would
+      // silently fail to match paths containing dot-prefixed segments (e.g.
+      // `.github/foo` or `my-project/.env.staging`), causing subprojects to
+      // appear inactive for PRs that touch only such paths.
+      const matches = minimatch.match(filenames, path, {"flipNegate": isNegation, "dot": true})
       // if it's a negation, delete from the list of hits, otherwise add
       matches.forEach((match: string) => (isNegation) ? hits.delete(match): hits.add(match))
     });


### PR DESCRIPTION
## Context

GitHub Actions' `paths:` filter uses minimatch with `dot: true`. Without it, patterns like `**` silently skip dot-prefixed paths — so a subproject keyed on `paths: ["**"]` won't activate for a PR that only touches files under `.github/`, `src/.foo`, etc., even though the intent of `**` is "match everything".

We hit this on a PR that modified only files under `.github/`, where our general lint subproject failed to activate. Working around it in `checkgroup.yml` requires enumerating every dot-segment permutation (`**`, `.*`, `.*/**`, `**/.*`, `**/.*/**`) and still doesn't cover paths with multiple non-adjacent dot segments. Fixing at the matcher is the right place.

## Change
Pass `dot: true` to minimatch in `matchFilenamesToSubprojects`.

## Notes
* Risks: `**` patterns match more things — same patterns activate subprojects for *more* PRs, never fewer. Net effect on consumers is stricter merge gating, not weaker. And aligns with how .github paths work. So I think this is a good change.
* Verification: Tested with the rebuilt `dist/`. A subproject keyed on `paths: ["**"]` now activates for inputs like `.gitignore`, `.github/workflows/foo.yml`, `my-project/.eslintrc`, `my-project/dot-config-staging` — none of which it activated for before.